### PR TITLE
Fixed end-of-steam bug in readBytes()

### DIFF
--- a/lib/data_input.dart
+++ b/lib/data_input.dart
@@ -43,7 +43,7 @@ class DataInput {
   }
   
   List<int> readBytes(int numBytes) {
-    if ((_offset + numBytes) < fileLength) {
+    if ((_offset + numBytes) <= fileLength) {
       int old_offset = _offset;
       _offset += numBytes;
       return data.getRange(old_offset, old_offset + numBytes).toList();


### PR DESCRIPTION
I encountered a bug where readUTF() failed when it the text is at the end of the stream.  This fixes the problem